### PR TITLE
Add watchdog url to config

### DIFF
--- a/loki/config.json
+++ b/loki/config.json
@@ -7,6 +7,7 @@
   "description": "Loki for Home Assistant",
   "startup": "system",
   "map": ["share", "ssl"],
+  "watchdog": "http://[HOST]/ready",
   "ports": {
     "3100/tcp": null
   },


### PR DESCRIPTION
Loki has a `/ready` API, add it as the watchdog URL for observer