### PR TITLE
Add port 80 to watchdog URL

### DIFF
--- a/loki/config.json
+++ b/loki/config.json
@@ -7,7 +7,7 @@
   "description": "Loki for Home Assistant",
   "startup": "system",
   "map": ["share", "ssl"],
-  "watchdog": "http://[HOST]/ready",
+  "watchdog": "http://[HOST]:80/ready",
   "ports": {
     "3100/tcp": null
   },


### PR DESCRIPTION
Looks like having a port on the watchdog URL isn't optional. Adding port 80 to it.