### PR TITLE
Block access to internal port externally

### DIFF
--- a/loki/DOCS.md
+++ b/loki/DOCS.md
@@ -74,8 +74,9 @@ Loki. You can also see examples [here][loki-doc-examples]. I would also strongly
 recommend reading the [Loki best practices][loki-doc-best-practices] guide before
 proceeding with a custom config.
 
-**Note**: `http_listen_port` and `log_level` are set by the add-on via CLI
-params so they cannot be changed. Everything else can be configured in your file.
+**Note**: `http_listen_address`, `http_listen_port` and `log_level` are set by
+the add-on via CLI params so they cannot be changed. Everything else can be configured
+in your file.
 
 ### Option: `log_level`
 

--- a/loki/config.json
+++ b/loki/config.json
@@ -7,7 +7,7 @@
   "description": "Loki for Home Assistant",
   "startup": "system",
   "map": ["share", "ssl"],
-  "watchdog": "http://[HOST]:80/ready",
+  "watchdog": "[PROTO:ssl]://[HOST]:[PORT:3100]/ready",
   "ports": {
     "3100/tcp": null
   },

--- a/loki/rootfs/etc/services.d/loki/run
+++ b/loki/rootfs/etc/services.d/loki/run
@@ -23,7 +23,12 @@ case "$(bashio::config 'log_level')" in \
 esac;
 bashio::log.info "Loki log level set to ${log_level}"
 
-loki_args=("-config.file=${loki_config}" "-server.http-listen-port=80" "-log.level=${log_level}")
+loki_args=(
+    "-config.file=${loki_config}"
+    "-server.http_listen_address=127.0.0.1"
+    "-server.http-listen-port=80" 
+    "-log.level=${log_level}"
+)
 if [ "${log_level}" == "debug" ]; then
     bashio::log.debug "Logging full config on startup for debugging..."
     loki_args+=("-print-config-stderr=true")


### PR DESCRIPTION
Set `http_listen_address` to `127.0.0.1` to prevent access directly to promtail and ensure access goes through nginx server.