### PR TITLE
Add retention options to limit disk usage

### DIFF
--- a/loki/DOCS.md
+++ b/loki/DOCS.md
@@ -62,6 +62,30 @@ The absolute path to the CA certificate used to sign client certificates. If set
 clients will be required to present a valid client-authentication certificate to
 connect to Loki (mTLS).
 
+### Option: `days_per_table`
+
+Number of days of logs to keep in each index table, default is one week. Used to
+set `index.period` in [period_config][loki-docs-period-config]. See [table manager][loki-docs-table-manager]
+for more information on how Loki handles retention.
+
+**Note**: This sets an environmental variable referenced in the [default config][addon-default-config].
+If you use `config_path` below it is ignored unless you reference the same variable.
+
+### Option: `tables_to_keep`
+
+Number of tables of logs to keep. The oldest table is deleted once the limit is
+reached. Minimum is `2` if set, defaults to `4` if omitted (i.e. one month when
+multiplied by default `days_to_keep`).
+
+This value minus one is multiplied by `days_per_table` to set `retention_period`
+in [table_manager_config][loki-docs-table-manager-config]. The minimum is because
+`0` tells Loki to keep tables indefinitely which causes the addon's disk usage
+to grow without bound. See [table manager][loki-docs-table-manager] for more
+information on how Loki handles retention.
+
+**Note**: This sets an environmental variable referenced in the [default config][addon-default-config].
+If you use `config_path` below it is ignored unless you reference the same variable.
+
 ### Option: `config_path`
 
 Absolute path to a custom config file for Loki. By default this addon will run

--- a/loki/config.json
+++ b/loki/config.json
@@ -16,8 +16,8 @@
   },
   "options": {
     "ssl": false,
-    "days_per_table": 1,
-    "tables_to_keep": 30,
+    "days_per_table": 7,
+    "tables_to_keep": 4,
     "log_level": "info"
   },
   "schema": {

--- a/loki/config.json
+++ b/loki/config.json
@@ -16,6 +16,8 @@
   },
   "options": {
     "ssl": false,
+    "days_per_table": 1,
+    "tables_to_keep": 30,
     "log_level": "info"
   },
   "schema": {
@@ -23,6 +25,8 @@
     "certfile": "str?",
     "keyfile": "str?",
     "cafile": "str?",
+    "days_per_table": "int(0,)?",
+    "tables_to_keep": "int(2,)?",
     "config_path": "str?",
     "log_level": "list(debug|info|warning|error)?"
   }

--- a/loki/rootfs/etc/loki/default-config.yaml
+++ b/loki/rootfs/etc/loki/default-config.yaml
@@ -25,7 +25,7 @@ schema_config:
       schema: v11
       index:
         prefix: index_
-        period: 24h
+        period: ${INDEX_PERIOD:168h}
 
 storage_config:
   boltdb_shipper:
@@ -48,5 +48,5 @@ chunk_store_config:
   max_look_back_period: 0s
 
 table_manager:
-  retention_deletes_enabled: false
-  retention_period: 0s
+  retention_deletes_enabled: true
+  retention_period: ${RETENTION_PERIOD:504h}

--- a/loki/rootfs/etc/services.d/loki/run
+++ b/loki/rootfs/etc/services.d/loki/run
@@ -15,6 +15,25 @@ else
     bashio::log.info "Using default config"
 fi
 
+days_per_table=7
+if bashio::config.exists 'days_per_table'; then
+    days_per_table=$(bashio::config 'days_per_table')
+fi
+index_period="$((days_per_table * 24))h"
+bashio::log.info "Index period set to ${index_period}"
+export "INDEX_PERIOD=${index_period}"
+
+tables_to_keep=4
+if bashio::config.exists 'tables_to_keep'; then
+    tables_to_keep=$(bashio::config 'tables_to_keep')
+fi
+# Subtract one because Loki keeps one more index period then we say
+# https://grafana.com/docs/loki/latest/operations/storage/table-manager/#retention
+tables_to_keep=$((tables_to_keep - 1))
+retention_period="$((tables_to_keep * days_per_table * 24))h"
+bashio::log.info "Retention period set to ${retention_period}"
+export "RETENTION_PERIOD=${retention_period}"
+
 case "$(bashio::config 'log_level')" in \
     error)	log_level='error' ;; \
     warning)	log_level='warn' ;; \
@@ -24,6 +43,7 @@ esac;
 bashio::log.info "Loki log level set to ${log_level}"
 
 loki_args=(
+    "-config.expand-env=true"
     "-config.file=${loki_config}"
     "-server.http-listen-address=127.0.0.1"
     "-server.http-listen-port=80" 


### PR DESCRIPTION
## Breaking change

The default index period has been changed from `24h` to `168h` to match Loki default. Additionally a default retention period has been set of `504h` (i.e. 21 days). Effectively this causes Loki to delete tables more then 28 days old (see [retention](https://grafana.com/docs/loki/latest/operations/storage/table-manager/#retention) to understand 28 vs. 21) instead of growing without bound like it does currently. 

New options have been added for `days_per_table` and `tables_to_keep` to give users control over this behavior. However you cannot replicate the old behavior with these options (since we should never grow without bound). If you really want to retain the old behavior you should copy the [prior default config](https://github.com/mdegat01/addon-loki/blob/5741113cb23743aa9b9f38da26f4081b8cd513d1/loki/rootfs/etc/loki/default-config.yaml) to your system and reference it with the `config_path` option.