### PR TITLE
Add `days_to_keep` option to control retention

### DIFF
--- a/loki/DOCS.md
+++ b/loki/DOCS.md
@@ -62,26 +62,16 @@ The absolute path to the CA certificate used to sign client certificates. If set
 clients will be required to present a valid client-authentication certificate to
 connect to Loki (mTLS).
 
-### Option: `days_per_table`
+### Option: `days_to_keep`
 
-Number of days of logs to keep in each index table, default is one week. Used to
-set `index.period` in [period_config][loki-docs-period-config]. See [table manager][loki-docs-table-manager]
-for more information on how Loki handles retention.
+Number of days of logs to keep, older logs will be purged from the index. If set,
+minimum is `2`, defaults to `30` if omitted.
 
-**Note**: This sets an environmental variable referenced in the [default config][addon-default-config].
-If you use `config_path` below it is ignored unless you reference the same variable.
-
-### Option: `tables_to_keep`
-
-Number of tables of logs to keep. The oldest table is deleted once the limit is
-reached. Minimum is `2` if set, defaults to `4` if omitted (i.e. one month when
-multiplied by default `days_to_keep`).
-
-This value minus one is multiplied by `days_per_table` to set `retention_period`
-in [table_manager_config][loki-docs-table-manager-config]. The minimum is because
-`0` tells Loki to keep tables indefinitely which causes the addon's disk usage
-to grow without bound. See [table manager][loki-docs-table-manager] for more
-information on how Loki handles retention.
+This value minus one is used to set `retention_period` in [table_manager_config][loki-doc-table-manager-config].
+We subtract one because Loki keeps one extra index period (`24h` in [default config][addon-default-config]).
+And the minimum exists because `0` tells Loki to keep tables indefinitely (and
+the addon to grow without bound). See [table manager][loki-doc-table-manager]
+for more information on how Loki stores data and handles retention.
 
 **Note**: This sets an environmental variable referenced in the [default config][addon-default-config].
 If you use `config_path` below it is ignored unless you reference the same variable.
@@ -283,6 +273,8 @@ SOFTWARE.
 [loki-doc-best-practices]: https://grafana.com/docs/loki/latest/best-practices/
 [loki-doc-clients]: https://grafana.com/docs/loki/latest/clients/
 [loki-doc-examples]: https://grafana.com/docs/loki/latest/configuration/examples/
+[loki-doc-table-manager]: https://grafana.com/docs/loki/latest/operations/storage/table-manager/
+[loki-doc-table-manager-config]: https://grafana.com/docs/loki/latest/configuration/#table_manager_config
 [loki-in-grafana]: https://grafana.com/docs/loki/latest/getting-started/grafana
 [mdegat01]: https://github.com/mdegat01
 [promtail-doc-installation]: https://grafana.com/docs/loki/latest/clients/promtail/installation/

--- a/loki/config.json
+++ b/loki/config.json
@@ -16,8 +16,7 @@
   },
   "options": {
     "ssl": false,
-    "days_per_table": 7,
-    "tables_to_keep": 4,
+    "days_to_keep": 30,
     "log_level": "info"
   },
   "schema": {
@@ -25,8 +24,7 @@
     "certfile": "str?",
     "keyfile": "str?",
     "cafile": "str?",
-    "days_per_table": "int(0,)?",
-    "tables_to_keep": "int(2,)?",
+    "days_to_keep": "int(2,)?",
     "config_path": "str?",
     "log_level": "list(debug|info|warning|error)?"
   }

--- a/loki/rootfs/etc/loki/default-config.yaml
+++ b/loki/rootfs/etc/loki/default-config.yaml
@@ -25,7 +25,7 @@ schema_config:
       schema: v11
       index:
         prefix: index_
-        period: ${INDEX_PERIOD:168h}
+        period: 24h
 
 storage_config:
   boltdb_shipper:
@@ -49,4 +49,4 @@ chunk_store_config:
 
 table_manager:
   retention_deletes_enabled: true
-  retention_period: ${RETENTION_PERIOD:504h}
+  retention_period: ${RETENTION_PERIOD:696h}

--- a/loki/rootfs/etc/services.d/loki/run
+++ b/loki/rootfs/etc/services.d/loki/run
@@ -15,22 +15,14 @@ else
     bashio::log.info "Using default config"
 fi
 
-days_per_table=7
-if bashio::config.exists 'days_per_table'; then
-    days_per_table=$(bashio::config 'days_per_table')
-fi
-index_period="$((days_per_table * 24))h"
-bashio::log.info "Index period set to ${index_period}"
-export "INDEX_PERIOD=${index_period}"
-
-tables_to_keep=4
-if bashio::config.exists 'tables_to_keep'; then
-    tables_to_keep=$(bashio::config 'tables_to_keep')
+days_to_keep=30
+if bashio::config.exists 'days_to_keep'; then
+    days_to_keep=$(bashio::config 'days_to_keep')
 fi
 # Subtract one because Loki keeps one more index period then we say
 # https://grafana.com/docs/loki/latest/operations/storage/table-manager/#retention
-tables_to_keep=$((tables_to_keep - 1))
-retention_period="$((tables_to_keep * days_per_table * 24))h"
+days_to_keep=$((days_to_keep - 1))
+retention_period="$((days_to_keep * 24))h"
 bashio::log.info "Retention period set to ${retention_period}"
 export "RETENTION_PERIOD=${retention_period}"
 


### PR DESCRIPTION
Add new config option for `days_to_keep` to allow users to specify how long to keep logs. Default is `30` if not specified as we do not want to grow without bound.

**Note**: This largely undoes the work in #16 as it turns out Loki does not recommend its own default for period (one week) when using boltdb-shipper storage. It clearly states you should use `24h` so this returns the default config to that and removes that option. Instead we just have one option - `days_to_keep`. Much easier.

This also makes next release much less of a breaking change as it only adds a default retention period, it does not change the existing schema anymore.