### PR TITLE
Run Loki as non-root user

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -44,7 +44,9 @@ RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
 COPY rootfs /
 RUN set -eux; \
-    mkdir -p /data/loki;
+    mkdir -p /data/loki; \
+    addgroup -S loki; \
+    adduser -u 12345 -h /data/loki -D -S loki -G loki;
 WORKDIR /data/loki
 
 # Build arguments

--- a/loki/rootfs/etc/fix-attrs.d/loki
+++ b/loki/rootfs/etc/fix-attrs.d/loki
@@ -1,0 +1,1 @@
+/data/loki true loki 0755 0755

--- a/loki/rootfs/etc/nginx/includes/upstream.conf
+++ b/loki/rootfs/etc/nginx/includes/upstream.conf
@@ -1,3 +1,3 @@
 upstream backend {
-	server 127.0.0.1:80;
+	server 127.0.0.1:8080;
 }

--- a/loki/rootfs/etc/services.d/loki/run
+++ b/loki/rootfs/etc/services.d/loki/run
@@ -37,7 +37,7 @@ loki_args=(
     "-config.expand-env=true"
     "-config.file=${loki_config}"
     "-server.http-listen-address=127.0.0.1"
-    "-server.http-listen-port=80" 
+    "-server.http-listen-port=8080" 
     "-log.level=${log_level}"
 )
 if [ "${log_level}" == "debug" ]; then

--- a/loki/rootfs/etc/services.d/loki/run
+++ b/loki/rootfs/etc/services.d/loki/run
@@ -46,4 +46,5 @@ if [ "${log_level}" == "debug" ]; then
 fi
 
 bashio::log.info "Handing over control to Loki..."
-loki "${loki_args[@]}"
+exec s6-setuidgid loki \
+    loki "${loki_args[@]}"

--- a/loki/rootfs/etc/services.d/nginx/run
+++ b/loki/rootfs/etc/services.d/nginx/run
@@ -4,7 +4,8 @@
 # Home Assistant Add-on: Loki
 # Runs the Nginx daemon
 # ==============================================================================
-bashio::net.wait_for 80
+bashio::net.wait_for 8080
 bashio::log.info "Starting NGinx..."
 
-exec nginx
+exec s6-setuidgid loki \
+    nginx


### PR DESCRIPTION
Run Loki and NGinx services as a non-root user as a security best practice.

Note that as a part of this Loki is now internally running on `8080` instead of `80` since `80` is privileged. This shouldn't make a difference since it was inaccessible outside of the container but felt it should be noted.