### PR TITLE
Fix permissions for nginx user

### DIFF
--- a/loki/rootfs/etc/cont-init.d/nginx.sh
+++ b/loki/rootfs/etc/cont-init.d/nginx.sh
@@ -38,3 +38,14 @@ if bashio::config.true 'ssl'; then
 else
     mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
 fi
+
+# make folders
+mkdir -p \
+    /var/lib/nginx \
+    /var/tmp/nginx
+
+# permissions
+chown -R loki:loki \
+    /etc/nginx \
+    /var/lib/nginx \
+    /var/tmp/nginx

--- a/loki/rootfs/etc/nginx/nginx.conf
+++ b/loki/rootfs/etc/nginx/nginx.conf
@@ -1,8 +1,8 @@
 # Run nginx in foreground.
 daemon off;
 
-# This is run inside Docker.
-user root;
+# Use user created for application
+user loki;
 
 # Pid storage location.
 pid /var/run/nginx.pid;

--- a/loki/rootfs/etc/services.d/nginx/run
+++ b/loki/rootfs/etc/services.d/nginx/run
@@ -7,5 +7,4 @@
 bashio::net.wait_for 8080
 bashio::log.info "Starting NGinx..."
 
-exec s6-setuidgid loki \
-    nginx
+exec nginx


### PR DESCRIPTION
Missed the `user root` at the top of `nginx.conf`, fixed it so we're running nginx as user correctly. Also had to `chown` a few more folders nginx needed.