### PR TITLE
Log non-push, non-watchdog access

### DIFF
--- a/loki/rootfs/etc/nginx/includes/locations.conf
+++ b/loki/rootfs/etc/nginx/includes/locations.conf
@@ -1,0 +1,8 @@
+location = /loki/api/v1/push {
+    proxy_pass http://backend;
+}
+
+location / {
+    access_log /proc/1/fd/1 homeassistant;
+    proxy_pass http://backend;
+}

--- a/loki/rootfs/etc/nginx/servers/direct-mtls.disabled
+++ b/loki/rootfs/etc/nginx/servers/direct-mtls.disabled
@@ -11,7 +11,5 @@ server {
     ssl_client_certificate %%cafile%%;
     ssl_verify_client on;
 
-    location / {
-    	proxy_pass http://backend;
-    }
+    include /etc/nginx/includes/locations.conf;
 }

--- a/loki/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/loki/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -8,7 +8,5 @@ server {
     ssl_certificate /ssl/%%certfile%%;
     ssl_certificate_key /ssl/%%keyfile%%;
 
-    location / {
-    	proxy_pass http://backend;
-    }
+    include /etc/nginx/includes/locations.conf;
 }

--- a/loki/rootfs/etc/nginx/servers/direct.disabled
+++ b/loki/rootfs/etc/nginx/servers/direct.disabled
@@ -4,7 +4,5 @@ server {
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
 
-    location / {
-        proxy_pass http://backend;
-    }
+    include /etc/nginx/includes/locations.conf;
 }


### PR DESCRIPTION
Instead of turning off access logging, just turn it off at the push and ready APIs. We don't want logging there since those endpoints are extremely chatty but log all other access as normal.