### PR TITLE
Log unexpected access at watchdog port

### DIFF
--- a/loki/rootfs/etc/nginx/servers/ready.conf
+++ b/loki/rootfs/etc/nginx/servers/ready.conf
@@ -9,6 +9,7 @@ server {
     }
 
     location / {
+        access_log /proc/1/fd/1 homeassistant;
         return 404;
     }
 }


### PR DESCRIPTION
Also log unexpected access at port that only allows `/ready` calls.