### PR TITLE
Add armhf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ SOFTWARE.
 [add-repo-shield]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [add-repo]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmdegat01%2Fhassio-addons
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
+[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/mdegat01/addon-loki.svg
 [commits]: https://github.com/mdegat01/addon-loki/commits/main

--- a/loki/build.json
+++ b/loki/build.json
@@ -1,6 +1,7 @@
 {
   "build_from": {
     "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.5",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.5",
     "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.5",
     "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.5"
   }

--- a/loki/config.json
+++ b/loki/config.json
@@ -3,7 +3,7 @@
   "url": "https://github.com/mdegat01/addon-loki",
   "version": "edge",
   "slug": "loki",
-  "arch": ["aarch64", "amd64", "armv7"],
+  "arch": ["aarch64", "amd64", "armv7", "armhf"],
   "description": "Loki for Home Assistant",
   "startup": "system",
   "map": ["share", "ssl"],


### PR DESCRIPTION
Adding support for `armhf` as I believe Loki does. I don't have a good way to test this since I don't have that type of machine available. But if the image builds it should be ok since it will run `loki -version` as a part of that build process. 