### PR TITLE
Deprecate absolute path support for cafile & support blanking out

### DIFF
--- a/loki/DOCS.md
+++ b/loki/DOCS.md
@@ -59,9 +59,11 @@ The private key file to use for SSL.
 
 ### Option: `cafile`
 
-The absolute path to the CA certificate used to sign client certificates. If set,
-clients will be required to present a valid client-authentication certificate to
-connect to Loki (mTLS).
+The CA certificate file used to sign client certificates. If set,cclients will
+be required to present a valid client-authentication certificate to connect to
+Loki (mTLS).
+
+**Note**: _The file MUST be stored in `/ssl/`, which is the default_
 
 ### Option: `days_to_keep`
 

--- a/loki/rootfs/etc/cont-init.d/nginx.sh
+++ b/loki/rootfs/etc/cont-init.d/nginx.sh
@@ -15,8 +15,20 @@ if bashio::config.true 'ssl'; then
     certfile=$(bashio::config 'certfile')
     keyfile=$(bashio::config 'keyfile')
 
-    if bashio::config.exists 'cafile'; then
+    if ! bashio::config.is_empty 'cafile'; then
         bashio::log.info 'Setting up mTLS...'
+        cafile=$(bashio::config 'cafile')
+
+        # Absolute path support deprecated 4/21 for release 1.5.0.
+        # Wait until at least 5/21 to remove
+        if [[ $cafile =~ ^\/ ]]; then
+            bashio::log.warning "Providing an absolute path for 'cafile' is deprecated."
+            bashio::log.warning "Support for absolute paths will be removed in a future release."
+            bashio::log.warning "Please put your CA file in /ssl and provide a relative path."
+        else
+            cafile="/ssl/${cafile}"
+        fi
+
         if ! bashio::fs.file_exists "$(bashio::config 'cafile')"; then
 	        bashio::log.fatal
 	        bashio::log.fatal "The file specified for 'cafile' does not exist!"


### PR DESCRIPTION
Based on other addons, correct approach is to be opinionated about where files should be. Therefore deprecating the ability to provide an absolute path for `cafile` and requiring it be in `/ssl`. Using an absolute path only gives a warning for now, will remove in a future release (sometime after May 2021).

Also switch check on `cafile` option to `is_empty` instead of `exists`. This works better with the UI-based config since it won't let you remove string-type config options, only blank them out.