### PR TITLE
Publish to beta explicitly

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -134,7 +134,7 @@ jobs:
       - information
       - deploy
     environment:
-      name: ${{ needs.information.outputs.environment }}
+      name: edge
     runs-on: ubuntu-latest
     steps:
       - name: 🚀 Dispatch repository updater update signal
@@ -159,7 +159,7 @@ jobs:
       - information
       - deploy
     environment:
-      name: ${{ needs.information.outputs.environment }}
+      name: beta
     runs-on: ubuntu-latest
     steps:
       - name: 🚀 Dispatch repository updater update signal
@@ -182,7 +182,7 @@ jobs:
       - information
       - deploy
     environment:
-      name: ${{ needs.information.outputs.environment }}
+      name: stable
     runs-on: ubuntu-latest
     steps:
       - name: 🚀 Dispatch repository updater update signal


### PR DESCRIPTION
Deploy workflow was using the collected environment variable to decide which environment to publish to instead of listing the env by name. This means stable releases published to stable twice instead of to beta and stable.