### PR TITLE
Use the `do_usr` variable

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -10,7 +10,7 @@ RUN set -eux; \
     apk update; \
     apk add --no-cache --virtual .build-deps \
         unzip=6.0-r8 \
-        curl=7.74.0-r1 \
+        curl=7.76.1-r0 \
         ; \
     APKARCH="$(apk --print-arch)"; \
     case "$APKARCH" in \

--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -38,7 +38,7 @@ profile loki flags=(attach_disconnected,mediate_deleted) {
   @{do_run}/s6/**                   rwix,
   @{do_run}/**                      rwk,
   /dev/tty                          rw,
-  @{fs_root}/usr/lib/locale/{,**}   r,
+  @{do_usr}/lib/locale/{,**}        r,
   @{do_etc_ro}/group                r,
   @{do_etc_ro}/passwd               r,
   @{do_etc_ro}/hosts                r,


### PR DESCRIPTION
Tiny change to use the `do_usr` variable instead of `@{fs_root}/usr/`