### PR TITLE
Remove Nginx access log

### DIFF
--- a/loki/rootfs/etc/nginx/includes/locations.conf
+++ b/loki/rootfs/etc/nginx/includes/locations.conf
@@ -1,8 +1,0 @@
-location = /loki/api/v1/push {
-    proxy_pass http://backend;
-}
-
-location / {
-    access_log /proc/1/fd/1 homeassistant;
-    proxy_pass http://backend;
-}

--- a/loki/rootfs/etc/nginx/servers/direct-mtls.disabled
+++ b/loki/rootfs/etc/nginx/servers/direct-mtls.disabled
@@ -11,5 +11,7 @@ server {
     ssl_client_certificate %%cafile%%;
     ssl_verify_client on;
 
-    include /etc/nginx/includes/locations.conf;
+    location / {
+        proxy_pass http://backend;
+    }
 }

--- a/loki/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/loki/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -8,5 +8,7 @@ server {
     ssl_certificate /ssl/%%certfile%%;
     ssl_certificate_key /ssl/%%keyfile%%;
 
-    include /etc/nginx/includes/locations.conf;
+    location / {
+        proxy_pass http://backend;
+    }
 }

--- a/loki/rootfs/etc/nginx/servers/direct.disabled
+++ b/loki/rootfs/etc/nginx/servers/direct.disabled
@@ -4,5 +4,7 @@ server {
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
 
-    include /etc/nginx/includes/locations.conf;
+    location / {
+        proxy_pass http://backend;
+    }
 }

--- a/loki/rootfs/etc/nginx/servers/ready.conf
+++ b/loki/rootfs/etc/nginx/servers/ready.conf
@@ -9,7 +9,6 @@ server {
     }
 
     location / {
-        access_log /proc/1/fd/1 homeassistant;
         return 404;
     }
 }


### PR DESCRIPTION
Nginx access log is noisy and unnecessary. Was already doing some filtering to prevent continuously logging of Promtail pushes, now following the direction taken in the community addons here and removing it entirely. Nginx is a daemon, Loki is the service. Nginx should be quiet unless it has an error.