### PR TITLE
AA - Allow loki to bind on unix dgram

### DIFF
--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -81,6 +81,7 @@ profile loki flags=(attach_disconnected,mediate_deleted) {
     network tcp,
     network udp,
     network netlink raw,
+    network unix dgram,
 
     # Addon data
     /data/**                        r,


### PR DESCRIPTION
Missed that one of the `dgram` requests was not for `inet` or `inet6` in #60. Adding that missing network access for Loki.