### PR TITLE
Bump addons base from `9.1.7` to `9.2.0`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -1,5 +1,4 @@
-# https://github.com/hassio-addons/addon-base/releases
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.7
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://hub.docker.com/_/alpine
 FROM alpine:3.13.5 as build
@@ -28,8 +27,8 @@ RUN set -eux; \
     rm /tmp/loki.zip;
 
 
-# hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+# https://github.com/hassio-addons/addon-base/releases
+FROM ${BUILD_FROM}:9.2.0
 
 # add Nginx
 RUN set -eux; \

--- a/loki/build.json
+++ b/loki/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.7",
-    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.7",
-    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.7",
-    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.7"
+    "amd64": "ghcr.io/hassio-addons/base/amd64",
+    "armhf": "ghcr.io/hassio-addons/base/armhf",
+    "armv7": "ghcr.io/hassio-addons/base/armv7",
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64"
   }
 }


### PR DESCRIPTION
Bumps hassio-addons/addon-base image from `9.1.7` to [9.2.0](https://github.com/hassio-addons/addon-base/releases/tag/v9.2.0)