### PR TITLE
Add docker to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: "/loki"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Let dependabot keep the dockerfile up to date (well at least the parts it understands)