### PR TITLE
Return `444` from `/ready` only upstream

### DIFF
--- a/loki/rootfs/etc/nginx/servers/ready.conf
+++ b/loki/rootfs/etc/nginx/servers/ready.conf
@@ -9,6 +9,6 @@ server {
     }
 
     location / {
-        return 404;
+        return 444;
     }
 }


### PR DESCRIPTION
In the upstream that only exists for healthchecks, use the nginx specific `444` status for any other paths instead of the generic `404`.