### PR TITLE
Bump addon base to `9.2.2`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:9.2.1
+FROM ${BUILD_FROM}:9.2.2
 
 # add Nginx
 RUN set -eux; \


### PR DESCRIPTION
Bump addon base from `9.2.1` to [9.2.2](https://github.com/hassio-addons/addon-base/releases/tag/v9.2.2)