### PR TITLE
Bump addon base to `10.0.0`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -8,7 +8,7 @@ ENV LOKI_VERSION 2.2.1
 RUN set -eux; \
     apk update; \
     apk add --no-cache --virtual .build-deps \
-        unzip=6.0-r8 \
+        unzip=6.0-r9 \
         curl=7.77.0-r1 \
         ; \
     APKARCH="$(apk --print-arch)"; \

--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:9.2.2
+FROM ${BUILD_FROM}:10.0.0
 
 # add Nginx
 RUN set -eux; \

--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -35,7 +35,7 @@ RUN set -eux; \
     apk update; \
     apk add --no-cache \
         ca-certificates=20191127-r5 \
-        nginx=1.18.0-r15 \
+        nginx=1.20.1-r3 \
         ; \
     update-ca-certificates; \
     nginx -v; \


### PR DESCRIPTION
Bump addon base from `9.2.2` to [10.0.0](https://github.com/hassio-addons/addon-base/releases/tag/v10.0.0). Also requires updates to following packages:
- unzip to `6.0-r9`
- nginx to `1.20.1-r3`