### PR TITLE
Update loki to `2.3.0`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.14.1 as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.2.1
+ENV LOKI_VERSION 2.3.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update loki from `2.2.1` to [2.3.0](https://github.com/grafana/loki/releases/tag/v2.3.0)