### PR TITLE
Bump addon base to `10.1.1`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:10.1.0
+FROM ${BUILD_FROM}:10.1.1
 
 # add Nginx
 RUN set -eux; \


### PR DESCRIPTION
Bump addon base from `10.1.0` to [10.1.1](https://github.com/hassio-addons/addon-base/releases/tag/v10.1.1)