### PR TITLE
Update to Loki `2.4.1`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.14.2 as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.3.0
+ENV LOKI_VERSION 2.4.1
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update from Loki `2.3.0` to [2.4.1](https://github.com/grafana/loki/releases/tag/v2.4.1) (note this also covers the more significant bump to minor version [2.4.0](https://github.com/grafana/loki/releases/tag/v2.4.0))