### PR TITLE
Grant required runtime usage in AA profile

### DIFF
--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -90,6 +90,8 @@ profile loki flags=(attach_disconnected,mediate_deleted) {
     @{do_etc}/hosts                           r,
     @{do_etc}/{nsswitch,resolv}.conf          r,
     @{PROC}/sys/net/core/somaxconn            r,
+    @{PROC}/cpuset                            r,
+    @{do_run}/s6/services/loki/wal/**         rw,
     @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   }
 


### PR DESCRIPTION
Loki seems to require access to `/proc/cpuset` and the `wal` folder inside its s6 services directory as of the latest version.