### PR TITLE
Create required wal folder in services directory

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -48,6 +48,7 @@ RUN set -eux; \
         /var/lib/nginx/tmp/uwsgi \
         /var/log/nginx \
         /run/nginx \
+        /run/s6/services/loki/wal/ \
         ; \
     touch /var/log/nginx/error.log; \
     \

--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -65,7 +65,7 @@ profile loki flags=(attach_disconnected,mediate_deleted) {
   /usr/bin/loki                               cx -> loki,
   /usr/sbin/nginx                             Cx -> nginx,
 
-  profile loki flags=(attach_disconnected,mediate_deleted,complain) {
+  profile loki flags=(attach_disconnected,mediate_deleted) {
     include <abstractions/base>
 
     # Receive signals from s6

--- a/loki/rootfs/etc/fix-attrs.d/permissions
+++ b/loki/rootfs/etc/fix-attrs.d/permissions
@@ -4,3 +4,4 @@
 /var/log/nginx true abc 0755 0755
 /usr/lib/nginx true abc 0755 0755
 /usr/share/nginx true abc 0755 0755
+/run/s6/services/loki/wal true abc 0755 0755


### PR DESCRIPTION
Create the required wal folder in loki's s6 services directory so permission can be granted to it for the loki user.