### PR TITLE
Change ingestor's wal directory

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -48,7 +48,6 @@ RUN set -eux; \
         /var/lib/nginx/tmp/uwsgi \
         /var/log/nginx \
         /run/nginx \
-        /run/s6/services/loki/wal/ \
         ; \
     touch /var/log/nginx/error.log; \
     \

--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -91,7 +91,6 @@ profile loki flags=(attach_disconnected,mediate_deleted) {
     @{do_etc}/{nsswitch,resolv}.conf          r,
     @{PROC}/sys/net/core/somaxconn            r,
     @{PROC}/@{pid}/cpuset                     r,
-    @{do_run}/s6/services/loki/wal/{,**}      rw,
     @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   }
 

--- a/loki/rootfs/etc/fix-attrs.d/permissions
+++ b/loki/rootfs/etc/fix-attrs.d/permissions
@@ -4,4 +4,3 @@
 /var/log/nginx true abc 0755 0755
 /usr/lib/nginx true abc 0755 0755
 /usr/share/nginx true abc 0755 0755
-/run/s6/services/loki/wal true abc 0755 0755

--- a/loki/rootfs/etc/loki/default-config.yaml
+++ b/loki/rootfs/etc/loki/default-config.yaml
@@ -16,6 +16,8 @@ ingester:
   chunk_target_size: 1048576
   chunk_retain_period: 30s
   max_transfer_retries: 0
+  wal:
+    dir: /data/loki/wal
 
 schema_config:
   configs:


### PR DESCRIPTION
Loki tries to put the wal directory in a place it has no access to. Moving the location within `/data/loki`