### PR TITLE
Bump addon base to `11.0.0`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -28,13 +28,13 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:10.2.3
+FROM ${BUILD_FROM}:11.0.0
 
 # add Nginx
 RUN set -eux; \
     apk update; \
     apk add --no-cache \
-        ca-certificates=20191127-r5 \
+        ca-certificates=20191127-r7 \
         nginx=1.20.2-r0 \
         ; \
     update-ca-certificates; \


### PR DESCRIPTION
Bump addon base from `10.2.3` to [11.0.0](https://github.com/hassio-addons/addon-base/releases/tag/v11.0.0).

Additionally bump the following packages to latest for alpine 3.15:

- ca-certificates: `20191127-r5` -> `20191127-r7`