### PR TITLE
Fix retention by using compactor

### DIFF
--- a/loki/rootfs/etc/loki/default-config.yaml
+++ b/loki/rootfs/etc/loki/default-config.yaml
@@ -41,14 +41,12 @@ storage_config:
 compactor:
   working_directory: /data/loki/boltdb-shipper-compactor
   shared_store: filesystem
+  retention_enabled: true
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
+  retention_period: ${RETENTION_PERIOD:29d}
 
 chunk_store_config:
   max_look_back_period: 0s
-
-table_manager:
-  retention_deletes_enabled: true
-  retention_period: ${RETENTION_PERIOD:696h}


### PR DESCRIPTION
Retention settings don't seem to be working. It looks like Loki no longer recommends using `table_manager` for this and now `compactor` supports it. Switching to that to try and fix this.
