### PR TITLE
Grant `rwk` access in `/tmp` to files owned by Loki user

### DIFF
--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -87,7 +87,7 @@ profile loki flags=(attach_disconnected,mediate_deleted) {
     /share/**                                 r,
 
     # Runtime usage
-    /tmp/marker-view-**                       rw,
+    /tmp/marker-view-**                       rwk,
     /usr/bin/loki                             rm,
     @{do_etc}/hosts                           r,
     @{do_etc}/{nsswitch,resolv}.conf          r,

--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -87,7 +87,7 @@ profile loki flags=(attach_disconnected,mediate_deleted) {
     /share/**                                 r,
 
     # Runtime usage
-    /tmp/marker-view-**                       rwk,
+    owner /tmp/**                             rwk,
     /usr/bin/loki                             rm,
     @{do_etc}/hosts                           r,
     @{do_etc}/{nsswitch,resolv}.conf          r,


### PR DESCRIPTION
Loki seems to need to make, lock and read files in tmp for compactor to work properly. Give it that access for files owned by its user.