### PR TITLE
Stop subtracting one from `days_to_keep`

### DIFF
--- a/loki/DOCS.md
+++ b/loki/DOCS.md
@@ -68,13 +68,11 @@ Loki (mTLS).
 ### Option: `days_to_keep`
 
 Number of days of logs to keep, older logs will be purged from the index. If set,
-minimum is `2`, defaults to `30` if omitted.
+minimum is `1`, defaults to `30` if omitted.
 
-This value minus one is used to set `retention_period` in [table_manager_config][loki-doc-table-manager-config].
-We subtract one because Loki keeps one extra index period (`24h` in [default config][addon-default-config]).
-And the minimum exists because `0` tells Loki to keep tables indefinitely (and
-the addon to grow without bound). See [table manager][loki-doc-table-manager]
-for more information on how Loki stores data and handles retention.
+The minimum exists because `0` tells Loki to keep tables indefinitely (and the
+addon to grow without bound). See [retention][loki-doc-retention] for more information
+on how Loki's Compactor handles retention.
 
 **Note**: This sets an environmental variable referenced in the [default config][addon-default-config].
 If you use `config_path` below it is ignored unless you reference the same variable.

--- a/loki/config.yaml
+++ b/loki/config.yaml
@@ -27,6 +27,6 @@ schema:
   certfile: str?
   keyfile: str?
   cafile: str?
-  days_to_keep: int(2,)?
+  days_to_keep: int(1,)?
   config_path: str?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?

--- a/loki/rootfs/etc/services.d/loki/run
+++ b/loki/rootfs/etc/services.d/loki/run
@@ -19,13 +19,7 @@ else
     bashio::log.info "Using default config"
 fi
 
-days_to_keep=30
-if bashio::config.exists 'days_to_keep'; then
-    days_to_keep=$(bashio::config 'days_to_keep')
-fi
-# Subtract one because Loki keeps one more index period then we say
-# https://grafana.com/docs/loki/latest/operations/storage/table-manager/#retention
-retention_period="$((days_to_keep - 1))d"
+retention_period="$(bashio::config 'days_to_keep' 1)d"
 bashio::log.info "Retention period set to ${retention_period}"
 export "RETENTION_PERIOD=${retention_period}"
 


### PR DESCRIPTION
The subtract one logic for `days_to_keep` is no longer necessary. Unlike table manager, compactor seems to just accept our provided period for retention policy as is. Removing this outdated logic and updating docs.