### PR TITLE
Update Loki to `2.4.2`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.15.0 as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.4.1
+ENV LOKI_VERSION 2.4.2
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update Loki from `2.4.1` to [2.4.2](https://github.com/grafana/loki/releases/tag/v2.4.2)