### PR TITLE
Allow access on docker root paths in debian

### DIFF
--- a/loki/apparmor.txt
+++ b/loki/apparmor.txt
@@ -1,7 +1,8 @@
 include <tunables/global>
 
 # Docker overlay
-@{fs_root}=/ /docker/overlay2/*/diff/
+@{docker_root}=/docker/ /var/lib/docker/
+@{fs_root}=/ @{docker_root}/overlay2/*/diff/
 @{do_etc}=@{fs_root}/etc/
 @{do_opt}=@{fs_root}/opt/
 @{do_run}=@{fs_root}/{run,var/run}/


### PR DESCRIPTION
In a debian system, docker maps containers to folders within `/var/lib/docker/overlay2`. Some commands see this path with certain commands within the container and permission was not granted there, only to `/docker/overlay2` (the docker root on other OS's). Added this support.
