### PR TITLE
Update Loki to `2.5.0`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.15.4 as build
 # https://github.com/grafana/loki/releases
-ENV LOKI_VERSION 2.4.2
+ENV LOKI_VERSION 2.5.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update Loki from `2.4.2` to [2.5.0](https://github.com/grafana/loki/releases/tag/v2.5.0)
