### PR TITLE
Bump hassio-addons/base to `11.1.2`

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:11.0.1
+FROM ${BUILD_FROM}:11.1.2
 
 # add Nginx
 RUN set -eux; \

--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -34,7 +34,7 @@ FROM ${BUILD_FROM}:11.1.2
 RUN set -eux; \
     apk update; \
     apk add --no-cache \
-        ca-certificates=20191127-r7 \
+        ca-certificates=20211220-r0 \
         nginx=1.20.2-r0 \
         ; \
     update-ca-certificates; \

--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -28,7 +28,8 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:11.1.2
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
 
 # add Nginx
 RUN set -eux; \

--- a/loki/build.yaml
+++ b/loki/build.yaml
@@ -1,6 +1,6 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/base/amd64
-  armhf: ghcr.io/hassio-addons/base/armhf
-  armv7: ghcr.io/hassio-addons/base/armv7
-  aarch64: ghcr.io/hassio-addons/base/aarch64
+  amd64: ghcr.io/hassio-addons/base/amd64:11.1.2
+  armhf: ghcr.io/hassio-addons/base/armhf:11.1.2
+  armv7: ghcr.io/hassio-addons/base/armv7:11.1.2
+  aarch64: ghcr.io/hassio-addons/base/aarch64:11.1.2


### PR DESCRIPTION
Bump hassio-addons/base from `11.0.1` to [11.1.2](https://github.com/hassio-addons/addon-base/releases/tag/v11.1.2)

Required package bumps:
- Bump ca-certificates from `20191127-r7` to `20211220-r0`
