### PR TITLE
Refactor build yaml args into dockerfile

### DIFF
--- a/loki/build.yaml
+++ b/loki/build.yaml
@@ -7,5 +7,3 @@ build_from:
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com
-args:
-  LOKI_VERSION: 2.5.0


### PR DESCRIPTION
They aren't pulled in by addon information so don't use them.