### PR TITLE
Update Loki to 2.6.1

### DIFF
--- a/loki/build.yaml
+++ b/loki/build.yaml
@@ -7,3 +7,5 @@ build_from:
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com
+args:
+  LOKI_VERSION: 2.6.1


### PR DESCRIPTION
Update Loki from `2.5.0` to [2.6.1](https://github.com/grafana/loki/releases/tag/v2.6.1) (note: includes milestone upgrade to [2.6.0](https://github.com/grafana/loki/releases/tag/v2.6.0))
