### PR TITLE
Remove loki version print in dockerfile

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -29,7 +29,6 @@ RUN set -eux; \
     chmod a+x /usr/bin/loki; \
     rm /tmp/loki.zip; \
     apk del .build-deps; \
-    loki --version; \
     \
     apk add --no-cache \
         ca-certificates=20211220-r0 \


### PR DESCRIPTION
Can't print loki version in dockerfile anymore. Apparently it now requires a config file just to print the current version
