### PR TITLE
Bump addon base 12.2.7

### DIFF
--- a/loki/Dockerfile
+++ b/loki/Dockerfile
@@ -32,7 +32,7 @@ RUN set -eux; \
     \
     apk add --no-cache \
         ca-certificates=20220614-r0 \
-        nginx=1.22.0-r1 \
+        nginx=1.22.1-r0 \
         ; \
     update-ca-certificates; \
     nginx -v; \

--- a/loki/build.yaml
+++ b/loki/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/base/amd64:12.2.3
-  armhf: ghcr.io/hassio-addons/base/armhf:12.2.3
-  armv7: ghcr.io/hassio-addons/base/armv7:12.2.3
-  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.3
+  amd64: ghcr.io/hassio-addons/base/amd64:12.2.7
+  armhf: ghcr.io/hassio-addons/base/armhf:12.2.7
+  armv7: ghcr.io/hassio-addons/base/armv7:12.2.7
+  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.7
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com


### PR DESCRIPTION
Bump addon base from `12.2.3` to [`12.2.7`](https://github.com/hassio-addons/addon-base/releases/tag/v12.2.7)

Also bump nginx
